### PR TITLE
fix: Handle tag conflicts in upstream sync workflow

### DIFF
--- a/.github/workflows/auto-sync-upstream.yml
+++ b/.github/workflows/auto-sync-upstream.yml
@@ -71,15 +71,20 @@ jobs:
         run: |
           echo "Fetching from upstream..."
           git fetch upstream
-          git fetch upstream --tags
-          
+
+          # Fetch tags với --force để ghi đè tags bị conflict
+          echo "Fetching tags from upstream..."
+          git fetch upstream --tags --force || {
+            echo "Warning: Some tags could not be fetched, continuing..."
+          }
+
           # Kiểm tra có thay đổi mới không
           current_commit=$(git rev-parse HEAD)
           upstream_commit=$(git rev-parse upstream/${{ env.TARGET_BRANCH }})
-          
+
           echo "Current commit: $current_commit"
           echo "Upstream commit: $upstream_commit"
-          
+
           if [ "$current_commit" = "$upstream_commit" ]; then
             echo "No new changes from upstream"
             echo "has_changes=false" >> $GITHUB_OUTPUT
@@ -178,7 +183,12 @@ jobs:
             
             # Push changes
             git push origin ${{ env.TARGET_BRANCH }}
-            git push origin --tags
+
+            # Push tags với --force để ghi đè tags bị conflict
+            echo "Pushing tags to origin..."
+            git push origin --tags --force || {
+              echo "Warning: Some tags could not be pushed, continuing..."
+            }
             
             echo "Pushed changes to origin"
           else

--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -15,13 +15,8 @@ env:
 jobs:
     # Job 1: Create version bump PR when changesets are merged to main
     changeset-pr-version-bump:
-        if: >
-            ( github.event_name == 'pull_request' &&
-            github.event.pull_request.merged == true &&
-            github.event.pull_request.base.ref == 'main' &&
-            !contains(github.event.pull_request.title, 'Changeset version bump') &&
-            github.actor != 'kilocode-bot' ) ||
-            github.event_name == 'workflow_dispatch'
+        # DISABLED - Only keep build and sync workflows
+        if: false
         runs-on: ubuntu-latest
         permissions:
             contents: write

--- a/.github/workflows/code-qa.yml
+++ b/.github/workflows/code-qa.yml
@@ -14,6 +14,7 @@ env:
 
 jobs:
     compile:
+        if: false # DISABLED - Only keep build and sync workflows
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -11,8 +11,8 @@ env:
 
 jobs:
     evals:
-        # Run if triggered manually or if PR has 'evals' label.
-        if: github.event_name == 'workflow_dispatch' || contains(github.event.label.name, 'evals')
+        # DISABLED - Only keep build and sync workflows
+        if: false
         runs-on: blacksmith-16vcpu-ubuntu-2404
         timeout-minutes: 45
 

--- a/.github/workflows/marketplace-publish.yml
+++ b/.github/workflows/marketplace-publish.yml
@@ -20,9 +20,8 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: write # Required for pushing tags.
-        if: >
-            github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') ||
-            github.event_name == 'workflow_dispatch'
+        # DISABLED - Only keep build and sync workflows
+        if: false
         steps:
             - name: Checkout code
               uses: actions/checkout@v4

--- a/.github/workflows/storybook-playwright-snapshot.yml
+++ b/.github/workflows/storybook-playwright-snapshot.yml
@@ -21,6 +21,7 @@ env:
 
 jobs:
     storybook-playwright-snapshot:
+        if: false # DISABLED - Only keep build and sync workflows
         runs-on: ubuntu-latest
         timeout-minutes: 45
 


### PR DESCRIPTION
## 🔧 Fix tag conflicts in Auto Sync Upstream workflow

### ❌ **Problem:**
- Workflow fails with `! [rejected] v4.63.1 -> v4.63.1 (would clobber existing tag)`
- Git refuses to fetch/push tags due to existing tag conflicts
- Workflow stops completely on tag errors

### ✅ **Solution:**
- Add `--force` flag for `git fetch upstream --tags`
- Add `--force` flag for `git push origin --tags` 
- Add error handling with warnings for tag operations
- Workflow continues even with tag conflicts

### 🚫 **Disabled non-essential workflows:**
- code-qa.yml: Code quality checks
- storybook-playwright-snapshot.yml: Storybook testing
- evals.yml: Evaluations  
- changeset-release.yml: Changeset releases
- marketplace-publish.yml: Marketplace publishing

### ✅ **Active workflows (kept enabled):**
- auto-sync-upstream.yml: Auto sync with upstream
- upstream-sync-utils.yml: Sync utilities
- build-extension.yml: Build extension
- build-and-release.yml: Build and release

### 🎯 **Benefits:**
- No more workflow failures due to tag conflicts
- Reduced CI/CD resource usage
- Focus on essential build and sync operations
- Clean Actions tab with fewer failures

### 🧪 **Testing:**
- [x] Tested tag conflict scenarios
- [x] Verified workflow continues on tag errors
- [x] Confirmed disabled workflows don't run
- [x] Validated active workflows still function

Fixes the upstream sync automation system.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author