### PR TITLE
fix: remove all duplicate gemini-cli cases and schema entries

### DIFF
--- a/packages/types/src/provider-settings.ts
+++ b/packages/types/src/provider-settings.ts
@@ -526,7 +526,6 @@ export const providerSettingsSchemaDiscriminated = z.discriminatedUnion("apiProv
 	fakeAiSchema.merge(z.object({ apiProvider: z.literal("fake-ai") })),
 	xaiSchema.merge(z.object({ apiProvider: z.literal("xai") })),
 	// kilocode_change start
-	geminiCliSchema.merge(z.object({ apiProvider: z.literal("gemini-cli") })),
 	kilocodeSchema.merge(z.object({ apiProvider: z.literal("kilocode") })),
 	virtualQuotaFallbackSchema.merge(z.object({ apiProvider: z.literal("virtual-quota-fallback") })),
 	syntheticSchema.merge(z.object({ apiProvider: z.literal("synthetic") })),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2942,10 +2942,6 @@ packages:
     resolution: {integrity: sha512-t3yaEOuGu9NlIZ+hIeGbBjFtZT7j2cb2tg0fuaJKeGotchRjjLfrBA9Kwf8quhpP1EUuxModQg04q/mBwyg8uA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/runtime@7.28.3':
-    resolution: {integrity: sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/runtime@7.28.4':
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
     engines: {node: '>=6.9.0'}
@@ -20003,8 +19999,6 @@ snapshots:
 
   '@babel/runtime@7.27.4': {}
 
-  '@babel/runtime@7.28.3': {}
-
   '@babel/runtime@7.28.4': {}
 
   '@babel/template@7.27.2':
@@ -20578,7 +20572,7 @@ snapshots:
       '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
       '@babel/preset-react': 7.27.1(@babel/core@7.28.3)
       '@babel/preset-typescript': 7.27.1(@babel/core@7.28.3)
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@babel/runtime-corejs3': 7.28.3
       '@babel/traverse': 7.28.3
       '@docusaurus/logger': 3.8.1
@@ -35410,7 +35404,7 @@ snapshots:
 
   react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@6.0.0(react@19.1.1))(webpack@5.101.3(esbuild@0.25.9)):
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.1.1)'
       webpack: 5.101.3(esbuild@0.25.9)
 
@@ -35465,13 +35459,13 @@ snapshots:
 
   react-router-config@5.1.1(react-router@5.3.4(react@19.1.1))(react@19.1.1):
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       react: 19.1.1
       react-router: 5.3.4(react@19.1.1)
 
   react-router-dom@5.3.4(react@19.1.1):
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       history: 4.10.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -35482,7 +35476,7 @@ snapshots:
 
   react-router@5.3.4(react@19.1.1):
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       history: 4.10.1
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -135,8 +135,6 @@ export function buildApiHandler(configuration: ProviderSettings): ApiHandler {
 		case "gemini":
 			return new GeminiHandler(options)
 		// kilocode_change start
-		case "gemini-cli":
-			return new GeminiCliHandler(options)
 		case "gemini-fj":
 			return new GeminiFjHandler(options)
 		// kilocode_change end

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -33,7 +33,6 @@ import {
 	LiteLLMHandler,
 	// kilocode_change start
 	VirtualQuotaFallbackHandler,
-	GeminiCliHandler,
 	// kilocode_change end
 	ClaudeCodeHandler,
 	QwenCodeHandler,

--- a/webview-ui/src/components/ui/hooks/useSelectedModel.ts
+++ b/webview-ui/src/components/ui/hooks/useSelectedModel.ts
@@ -376,11 +376,6 @@ function getSelectedModel({
 				info: routerModels["kilocode-openrouter"][invalidOrDefaultModel],
 			}
 		}
-		case "gemini-cli": {
-			const id = apiConfiguration.apiModelId ?? geminiCliDefaultModelId
-			const info = geminiCliModels[id as keyof typeof geminiCliModels]
-			return { id, info }
-		}
 		case "virtual-quota-fallback": {
 			return {
 				id: apiConfiguration.apiModelId ?? anthropicDefaultModelId,


### PR DESCRIPTION
## 🐛 Bug Fix

### Vấn đề
Extension Kilo Code không hiển thị UI trong VS Code do lỗi Zod schema validation:
```
Error: Discriminator property apiProvider has duplicate value gemini-cli
```

### Nguyên nhân
Sau khi merge upstream/main, có nhiều duplicate entries cho `gemini-cli`:
1. Duplicate trong Zod discriminatedUnion schema (packages/types/src/provider-settings.ts)
2. Duplicate import của GeminiCliHandler (src/api/index.ts)
3. Duplicate case trong switch statements (src/api/index.ts, webview-ui/src/components/ui/hooks/useSelectedModel.ts)

### Giải pháp
✅ Xóa tất cả các duplicate entries:
- Removed duplicate `gemini-cli` from Zod schema (line 529)
- Removed duplicate `GeminiCliHandler` import (line 36)
- Removed duplicate `case "gemini-cli"` in buildApiHandler (line 138-139)
- Removed duplicate `case "gemini-cli"` in useSelectedModel (line 379-383)

### Testing
- ✅ Build extension thành công locally
- ✅ ESLint pass
- ✅ TypeScript type check pass
- ⏳ Chờ GitHub Actions Build Extension workflow

### Related
- Fixes extension activation error
- Related to upstream merge #XXX